### PR TITLE
FIX: Observe Stream workaround; Accept only Non Observe requests after WS has been opened

### DIFF
--- a/client-examples/createNetworkWithDevice.js
+++ b/client-examples/createNetworkWithDevice.js
@@ -4,7 +4,7 @@ coap.registerOption('111', Buffer, String);
 
 const reqParams = {
     host: 'localhost',
-    port: 5683
+    port: 53
 };
 
 const obsReqParams  = {

--- a/client-examples/createNetworkWithDevice.js
+++ b/client-examples/createNetworkWithDevice.js
@@ -3,12 +3,16 @@ const coap = require('coap');
 coap.registerOption('111', Buffer, String);
 
 const reqParams = {
-    observe: true,
     host: 'localhost',
-    port: 53
+    port: 5683
 };
 
-coap.request(reqParams).on('response', resStream => {
+const obsReqParams  = {
+    observe: true,
+    ...reqParams
+};
+
+coap.request(obsReqParams).on('response', resStream => {
     resStream.on('data', data => {
         const msg = JSON.parse(data.toString());
 

--- a/src/CoapProxyWS.js
+++ b/src/CoapProxyWS.js
@@ -1,4 +1,4 @@
-const coap = require('coap');
+const coap = require('./coap');
 const WS = require('ws');
 const debug = require('debug')('coap-proxy');
 
@@ -69,7 +69,6 @@ class CoapProxy {
                 debug(`id: ${id.value} — CoAP message ${stringMsg}`);
             });
         } else {
-            this._piggybackedResponse(coapConnection);
             this._establishWebsocket(coapConnection);
         }
     }

--- a/src/CoapProxyWS.js
+++ b/src/CoapProxyWS.js
@@ -9,7 +9,7 @@ class CoapProxy {
         }
 
         this._target = target;
-        this._server = coap.createServer();
+        this._server = coap.createServer({ piggybackReplyMs: 1 });
         this._sockets = new Map();
         this._maxWSConnections = maxConnections;
 

--- a/src/CoapProxyWS.js
+++ b/src/CoapProxyWS.js
@@ -48,14 +48,18 @@ class CoapProxy {
 
                 if (this.hasReachedMaxWSConnections()) {
                     debug('Proxy has reached maximum WS connections! Rejecting request...');
-                    res.end(JSON.stringify({ error: 'proxy has reached maximum WS connections' }));
+                    res.end(JSON.stringify({ error: 'Proxy has reached maximum WS connections' }));
                     return;
                 }
 
-                this._handleObserveRequest(req, res);
+                if (this._getSocket(req)) {
+                    res.end(JSON.stringify({ error: 'Socket with this ID (111 header) already exists, please issue not oberve request to send WS message' }));
+                } else {
+                    this._handleRequest(req, res);
+                }
             } else {
                 if (this._getSocket(req)) {
-                    this._handleObserveRequest(req, res);
+                    this._handleRequest(req, res);
                 } else {
                     debug('Not Observe request to unexisting socket, rejecting...');
                     res.end(JSON.stringify({ error: 'Valid 111 header (socket ID) is required' }));
@@ -64,7 +68,7 @@ class CoapProxy {
         });
     }
 
-    _handleObserveRequest(coapReq, coapConnection) {
+    _handleRequest(coapReq, coapConnection) {
         const socket = this._getSocket(coapReq);
 
         if (socket) {

--- a/src/coap.js
+++ b/src/coap.js
@@ -3,6 +3,8 @@ const OutgoingMessage = require('coap/lib/outgoing_message');
 const observeWriteStreamPath = 'coap/lib/observe_write_stream';
 const ObserveWriteStream = require(observeWriteStreamPath);
 
+// THIS IS WORKAROUND
+// @TODO Contribute fix to the coap module
 require.cache[require.resolve(observeWriteStreamPath)].exports = function(...args) {
     const stream = new ObserveWriteStream(...args);
 

--- a/src/coap.js
+++ b/src/coap.js
@@ -1,0 +1,14 @@
+const OutgoingMessage = require('coap/lib/outgoing_message');
+
+const observeWriteStreamPath = 'coap/lib/observe_write_stream';
+const ObserveWriteStream = require(observeWriteStreamPath);
+
+require.cache[require.resolve(observeWriteStreamPath)].exports = function(...args) {
+    const stream = new ObserveWriteStream(...args);
+
+    OutgoingMessage.apply(stream, args);
+
+    return stream;
+};
+
+module.exports = require('coap');

--- a/test/unit/src/CoapProxyWS.js
+++ b/test/unit/src/CoapProxyWS.js
@@ -15,7 +15,11 @@ const SOCKET_ID_OPTION = '111';
 const coapRequestParams = {
     host: HOST_TEST,
     port: COAP_PORT_TEST,
-    method: 'GET',
+    method: 'GET'
+};
+
+const coapObserveRequestParams = {
+    ...coapRequestParams,
     observe: true
 };
 
@@ -38,12 +42,12 @@ describe('Coap Proxy module', function() {
         proxy.maxWSConnections(10);
     });
 
-    it('Should proxy CoAP request to WS server', done => {
+    it('Should proxy CoAP request to WS server connection', done => {
         wsServer.on('connection', socket => {
             done();
         });
 
-        coap.request(coapRequestParams).end();
+        coap.request(coapObserveRequestParams).end();
     });
 
     it('Should proxy messages from WS server', done => {
@@ -51,7 +55,7 @@ describe('Coap Proxy module', function() {
             socket.send('{"test":"test"}');
         });
 
-        coap.request(coapRequestParams).on('response', res => {
+        coap.request(coapObserveRequestParams).on('response', res => {
             res.on('data', data => {
                 const msg = JSON.parse(data.toString());
 
@@ -65,40 +69,17 @@ describe('Coap Proxy module', function() {
         }).end();
     });
 
-    it('Should send first piggybacked response in case request is valid (observe request) with status 0', done => {
-        let msgCount = 0;
-        coap.request(coapRequestParams).on('response', res => {
+    it('Should send response when WS is opened and ID is created', done => {
+        coap.request(coapObserveRequestParams).on('response', res => {
             res.on('data', data => {
                 const msg = JSON.parse(data.toString());
-
-                if (msgCount === 0 && msg.status === 0) {
-                    done();
-                    return;
-                } else if (msgCount !== 0) {
-                    done(new Error('First piggybacked response does not have status 0'));
-                }
-
-                msgCount++;
+                assert.notEqual(typeof msg.id, 'undefined');
+                done();
             });
         }).end();
     });
 
-    it('Should send second response when WS is opened and ID is created', done => {
-        let msgCount = 0;        
-        coap.request(coapRequestParams).on('response', res => {
-            res.on('data', data => {
-                msgCount++;
-
-                if (msgCount === 2) {
-                    const msg = JSON.parse(data.toString());
-                    assert.notEqual(typeof msg.id, 'undefined');
-                    done();
-                }
-            });
-        }).end();
-    });
-
-    it('Should proxy further coap observe requests as messages to WS server', done => {
+    it('Should proxy further coap requests (not OBSERVE) as messages to WS server', done => {
         wsServer.on('connection', socket => {
             socket.on('message', msg => {
                 assert.equal(msg.toString(), 'test');
@@ -108,7 +89,7 @@ describe('Coap Proxy module', function() {
 
         coap.registerOption('111', str => new Buffer(str), buff => buff.toString());
 
-        coap.request(coapRequestParams).on('response', res => {
+        coap.request(coapObserveRequestParams).on('response', res => {
             res.on('data', data => {
                 const msg = JSON.parse(data.toString());
                 
@@ -150,6 +131,7 @@ describe('Coap Proxy module', function() {
         const client = udp.createSocket('udp4');
 
         wsServer.on('connection', socket => {
+            socket.send('test'); // WORKAROUND TO MAKE CUSTOM CLIENT RESEND RESET MESSAGE
             socket.on('close', () => {
                 client.close();
                 done();
@@ -159,6 +141,7 @@ describe('Coap Proxy module', function() {
         sendObserveRequest(client);
 
         client.on('message', msg => {
+            // send reset
             const packet = coapPacket.parse(msg);
             const message = coapPacket.generate({
                 reset: true,
@@ -175,7 +158,7 @@ describe('Coap Proxy module', function() {
             res.on('data', data => {
                 const msg = JSON.parse(data.toString());
 
-                assert.equal(msg.error, 'Only Observe requests are supported');
+                assert.equal(msg.error, 'Valid 111 header (socket ID) is required');
                 done();
             });
         }).end();
@@ -184,12 +167,12 @@ describe('Coap Proxy module', function() {
     it('Should respond with error in case proxy has reached maximum WS connections', done => {
         proxy.maxWSConnections(1);
 
-        coap.request(coapRequestParams).on('response', res => {
+        coap.request(coapObserveRequestParams).on('response', res => {
             res.on('data', data => {
                 const msg = JSON.parse(data.toString());
 
                 if (msg.id) {
-                    coap.request(coapRequestParams).on('response', res => {
+                    coap.request(coapObserveRequestParams).on('response', res => {
                         res.on('data', data => {
                             const msg = JSON.parse(data.toString());
 

--- a/test/unit/src/CoapProxyWS.js
+++ b/test/unit/src/CoapProxyWS.js
@@ -23,7 +23,7 @@ const coapObserveRequestParams = {
     observe: true
 };
 
-describe('Coap Proxy module', function() {
+describe('CoAP Proxy', function() {
     this.timeout(300);
 
     let wsServer;
@@ -177,7 +177,7 @@ describe('Coap Proxy module', function() {
                             const msg = JSON.parse(data.toString());
 
                             if (msg.error) {
-                                assert.equal(msg.error, 'proxy has reached maximum WS connections');
+                                assert.equal(msg.error, 'Proxy has reached maximum WS connections');
                                 done();
                             }
                         });


### PR DESCRIPTION
- Remove piggybacked response for each request, only empty ACK is sent as immediate response; main response will come later - done by [RFC ](https://tools.ietf.org/html/rfc7252#section-5.2.2)